### PR TITLE
Add baseline client update without distillation

### DIFF
--- a/training/client_update_baseline.py
+++ b/training/client_update_baseline.py
@@ -1,0 +1,33 @@
+import copy
+import torch.optim as optim
+from utils.loss_function import cross_entropy_loss
+
+
+def client_update_baseline(global_model, local_data, learning_rate, device):
+    """Perform local training for a single client using only cross-entropy loss.
+
+    Parameters:
+        global_model: The global model to be cloned for local training.
+        local_data: DataLoader containing the client's local data.
+        learning_rate (float): Learning rate for the optimizer.
+        device: Device on which to perform training.
+
+    Returns:
+        dict: Updated state dictionary of the locally trained model.
+    """
+    # Clone the global model so the original weights remain unchanged
+    local_model = copy.deepcopy(global_model).to(device)
+    local_model.train()
+
+    optimizer = optim.SGD(local_model.parameters(), lr=learning_rate)
+
+    for inputs, labels in local_data:
+        inputs, labels = inputs.to(device), labels.to(device)
+        outputs = local_model(inputs)
+        loss = cross_entropy_loss(outputs, labels)
+
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+
+    return local_model.state_dict()


### PR DESCRIPTION
## Summary
- add `client_update_baseline` for FedAvg baseline training using only cross-entropy

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1b5b89664832fa755675c619c380d