### PR TITLE
Allow algorithm selection for federated experiments

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,3 +1,6 @@
+# Algorithm
+algorithm: fedavg_kd
+
 # Hyperparameters
 lambda_: 0.5
 T: 2.0


### PR DESCRIPTION
## Summary
- add `algorithm` setting in config
- select baseline or KD client updates based on chosen algorithm
- expose `--algorithm` CLI arg for experiments

## Testing
- `python run_experiment.py --help`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1b7a6d404832f83425a40dab72753