### PR TITLE
Document algorithm flag and non-IID behavior

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,4 +1,6 @@
 # Algorithm
+#   fedavg: baseline Federated Averaging
+#   fedavg_kd: Federated Averaging with knowledge distillation
 algorithm: fedavg_kd
 
 # Hyperparameters

--- a/readme.md
+++ b/readme.md
@@ -31,3 +31,24 @@ This project enhances the Federated Averaging (FedAvg) algorithm with a knowledg
         mlflow ui --backend-store-uri mlruns
         ```
     - Open `http://localhost:5000` in your browser to explore runs, metrics, and model artifacts.
+
+## Running Experiments
+
+The `algorithm` configuration flag selects between the baseline and the improved approach:
+
+* `fedavg` – standard Federated Averaging.
+* `fedavg_kd` – FedAvg with a knowledge distillation regularizer.
+
+You can change the value in `config/config.yaml` or override it on the command line:
+
+```bash
+# Baseline FedAvg
+python run_experiment.py --algorithm fedavg
+
+# Improved FedAvg with knowledge distillation
+python run_experiment.py --algorithm fedavg_kd
+```
+
+## Expected Behavior on Non-IID Data
+
+Non-IID client data often causes the baseline FedAvg to drift, reducing global model accuracy. The knowledge distillation variant is designed to counter this drift by aligning client models, typically leading to higher accuracy on non-IID splits. Metrics and model artifacts for both variants are logged to the `mlruns/` directory and can be compared in the MLflow UI.


### PR DESCRIPTION
## Summary
- Clarify `algorithm` config flag with options for baseline `fedavg` and improved `fedavg_kd`
- Add README section showing how to run both variants and describing expected behavior on non-IID data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1b8a4e6e8832fa97157c02e4d3f1b