### PR TITLE
Expose training parameters and unify test batch size

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -19,3 +19,5 @@ seed: 42
 # Training parameters
 epochs: 10
 learning_rate: 0.01
+local_epochs: 1          # number of local training passes per client
+client_fraction: 1.0     # fraction C of clients sampled each round


### PR DESCRIPTION
## Summary
- Add `local_epochs` and `client_fraction` to `config.yaml` for finer control over federated training
- Load batch size from config in tests to ensure baseline and KD runs share settings

## Testing
- `pytest tests/test_kd_vs_baseline.py -q` *(fails: URLError: <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bce88204832f933baf5dfa455447