### PR TITLE
feat: support custom shard sizing

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -14,6 +14,7 @@ batch_size: 64
 model_name: cifar_cnn
 num_clients: 1
 non_iid: false
+shards_per_client: 1
 seed: 42
 
 # Training parameters

--- a/run_experiment.py
+++ b/run_experiment.py
@@ -64,6 +64,7 @@ def run_experiment(config):
             config['batch_size'],
             num_clients=config.get('num_clients', 1),
             non_iid=config.get('non_iid', False),
+            shards_per_client=config.get('shards_per_client', 2),
             seed=config.get('seed'),
         )
 

--- a/tests/test_kd_vs_baseline.py
+++ b/tests/test_kd_vs_baseline.py
@@ -45,6 +45,7 @@ def prepare_data(seed: int, batch_size: int,
         batch_size,
         num_clients=num_clients,
         non_iid=True,
+        shards_per_client=1,
         seed=seed,
     )
 

--- a/utils/data_loader.py
+++ b/utils/data_loader.py
@@ -66,6 +66,7 @@ def load_data(
     batch_size: int,
     num_clients: int = 1,
     non_iid: bool = False,
+    shards_per_client: int = 2,
     seed: Optional[int] = None,
 ):
     """Load dataset and return DataLoaders for clients and test set."""
@@ -120,7 +121,13 @@ def load_data(
     else:
         raise ValueError(f"Unsupported dataset: {dataset_name}")
 
-    subsets = _split_dataset(train_dataset, num_clients, non_iid, seed=seed)
+    subsets = _split_dataset(
+        train_dataset,
+        num_clients,
+        non_iid,
+        shards_per_client=shards_per_client,
+        seed=seed,
+    )
     train_loaders = [
         DataLoader(subset, batch_size=batch_size, shuffle=True) for subset in subsets
     ]


### PR DESCRIPTION
## Summary
- allow custom shard size when splitting datasets
- expose `shards_per_client` in configuration and experiment code
- use smaller shard counts in tests for quicker local epochs

## Testing
- `pytest -q` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b2859f1d04832fac36507949bd247e