### PR TITLE
Ensure teacher eval mode and move distillation loss computation

### DIFF
--- a/models/teacher_model.py
+++ b/models/teacher_model.py
@@ -10,6 +10,7 @@ class TeacherModel(nn.Module):
         self.freeze()
 
     def freeze(self):
+        self.model.eval()
         for param in self.model.parameters():
             param.requires_grad = False
         return self

--- a/training/client_update.py
+++ b/training/client_update.py
@@ -39,10 +39,9 @@ def client_update(global_model, local_data, lambda_, T, tau, learning_rate, devi
             teacher_probs = torch.softmax(teacher_out / T, dim=1)
             conf, _ = teacher_probs.max(dim=1)
 
-            kd_loss = distillation_loss(teacher_out, student_out, T)
-
             # Apply distillation only when average confidence exceeds the threshold
             if conf.mean() >= tau:
+                kd_loss = distillation_loss(teacher_out, student_out, T)
                 loss = ce_loss + lambda_ * kd_loss
             else:
                 loss = ce_loss


### PR DESCRIPTION
## Summary
- Ensure the teacher model runs in evaluation mode by calling `eval()` during freezing
- Skip unnecessary distillation loss calculations unless confidence meets threshold

## Testing
- `pytest -q` *(fails: urllib.error.URLError: <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_68b295921b9c832f95c7e67380b8ff81