### PR TITLE
Remove redundant key stripping for aggregated weights

### DIFF
--- a/run_experiment.py
+++ b/run_experiment.py
@@ -121,13 +121,8 @@ def run_experiment(config):
                 client_sizes.append(len(client_loader.dataset))
 
             aggregated_weights = server_aggregation(client_weights, client_sizes)
-
-            # Create a new dictionary with the corrected keys
-            fixed_aggregated_weights = {
-                key.replace('model.', ''): value 
-                for key, value in aggregated_weights.items()
-            }
-            global_model.load_state_dict(fixed_aggregated_weights)
+            # Load the aggregated weights directly without modifying keys
+            global_model.load_state_dict(aggregated_weights)
 
             accuracy, avg_loss = evaluate_model(global_model, test_loader, cross_entropy_loss, device)
             print(f"Validation Accuracy: {accuracy:.2f}% | Validation Loss: {avg_loss:.4f}")

--- a/tests/test_kd_vs_baseline.py
+++ b/tests/test_kd_vs_baseline.py
@@ -69,8 +69,7 @@ def run_fedavg(train_loaders, test_loader, epochs: int, lr: float, device, local
             client_weights.append(weights)
             client_sizes.append(len(loader.dataset))
         aggregated = server_aggregation(client_weights, client_sizes)
-        fixed = {k.replace('model.', ''): v for k, v in aggregated.items()}
-        model.load_state_dict(fixed)
+        model.load_state_dict(aggregated)
     acc, _ = evaluate_model(model, test_loader, cross_entropy_loss, device)
     return acc
 
@@ -88,8 +87,7 @@ def run_fedavg_kd(train_loaders, test_loader, epochs: int,
             client_weights.append(weights)
             client_sizes.append(len(loader.dataset))
         aggregated = server_aggregation(client_weights, client_sizes)
-        fixed = {k.replace('model.', ''): v for k, v in aggregated.items()}
-        model.load_state_dict(fixed)
+        model.load_state_dict(aggregated)
     acc, _ = evaluate_model(model, test_loader, cross_entropy_loss, device)
     return acc
 

--- a/training/client_update.py
+++ b/training/client_update.py
@@ -52,4 +52,5 @@ def client_update(global_model, local_data, lambda_, T, tau, learning_rate, devi
             loss.backward()
             optimizer.step()
 
-    return student.state_dict()
+    # Return only the underlying model's parameters to avoid the 'model.' prefix
+    return student.model.state_dict()


### PR DESCRIPTION
## Summary
- Return underlying model parameters from `client_update`
- Load aggregated weights directly without renaming keys
- Align tests with new weight-loading approach

## Testing
- ⚠️ `pytest -q` *(fails: URLError: <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ad9450b4832f8bd572461a7d5ac1