### PR TITLE
Handle next-token targets for Shakespeare dataset

### DIFF
--- a/training/client_update.py
+++ b/training/client_update.py
@@ -28,6 +28,9 @@ def client_update(global_model, local_data, lambda_, T, tau, learning_rate, devi
     for _ in range(local_epochs):
         for inputs, labels in local_data:
             inputs, labels = inputs.to(device), labels.to(device)
+            # If labels are provided as sequences, use only the next token
+            if labels.dim() > 1:
+                labels = labels[:, -1]
             # Teacher and student predictions (raw logits)
             teacher_out = teacher(inputs)
             student_out = student(inputs)

--- a/training/client_update_baseline.py
+++ b/training/client_update_baseline.py
@@ -25,6 +25,9 @@ def client_update_baseline(global_model, local_data, learning_rate, device, loca
     for _ in range(local_epochs):
         for inputs, labels in local_data:
             inputs, labels = inputs.to(device), labels.to(device)
+            # If labels come as sequences, focus on the next character only
+            if labels.dim() > 1:
+                labels = labels[:, -1]
             outputs = local_model(inputs)
             loss = cross_entropy_loss(outputs, labels)
 

--- a/utils/data_loader.py
+++ b/utils/data_loader.py
@@ -113,7 +113,8 @@ def load_data(
 
             def __getitem__(self, idx):
                 x = self.data[idx:idx + self.seq_len]
-                y = self.data[idx + 1: idx + self.seq_len + 1]
+                # Use the next character as the target rather than a full sequence
+                y = self.data[idx + self.seq_len]
                 return x, y
 
         train_dataset = ShakespeareDataset(train_data, seq_len)

--- a/utils/evaluation.py
+++ b/utils/evaluation.py
@@ -25,6 +25,9 @@ def evaluate_model(model, test_loader, criterion, device):
     with torch.no_grad():
         for inputs, labels in test_loader:
             inputs, labels = inputs.to(device), labels.to(device)
+            # Handle datasets that provide sequence labels by selecting the next token
+            if labels.dim() > 1:
+                labels = labels[:, -1]
             # Forward pass
             outputs = model(inputs)
             loss = criterion(outputs, labels)


### PR DESCRIPTION
## Summary
- Use next character as target in Shakespeare dataset
- Ensure training and evaluation collapse sequence labels to single token when needed

## Testing
- `pip install pytest` *(fails: externally-managed-environment)*
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68b2adc72ea8832f92f9363b364b7199