### PR TITLE
Add MNIST CNN architecture and loader support

### DIFF
--- a/models/architectures.py
+++ b/models/architectures.py
@@ -52,6 +52,29 @@ class FEMNISTCNN(nn.Module):
         return x
 
 
+class MNISTCNN(nn.Module):
+    """Compact CNN for MNIST digit classification."""
+    def __init__(self, num_classes: int = 10):
+        super().__init__()
+        self.features = nn.Sequential(
+            nn.Conv2d(1, 32, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.MaxPool2d(2),
+            nn.Conv2d(32, 64, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.MaxPool2d(2),
+        )
+        self.classifier = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(64 * 7 * 7, num_classes),
+        )
+
+    def forward(self, x):
+        x = self.features(x)
+        x = self.classifier(x)
+        return x
+
+
 class ShakespeareLSTM(nn.Module):
     """LSTM model for character-level Shakespeare dataset."""
     def __init__(self, vocab_size: int = 80, embedding_dim: int = 8,
@@ -67,3 +90,11 @@ class ShakespeareLSTM(nn.Module):
         output, _ = self.lstm(x)
         output = self.fc(output[:, -1, :])
         return output
+
+
+__all__ = [
+    "CIFARCNN",
+    "FEMNISTCNN",
+    "MNISTCNN",
+    "ShakespeareLSTM",
+]

--- a/run_experiment.py
+++ b/run_experiment.py
@@ -10,7 +10,12 @@ from training.client_update_baseline import client_update_baseline
 from training.server_aggregation import server_aggregation
 from utils.data_loader import load_data
 from utils.evaluation import evaluate_model
-from models.architectures import CIFARCNN, FEMNISTCNN, ShakespeareLSTM
+from models.architectures import (
+    CIFARCNN,
+    FEMNISTCNN,
+    MNISTCNN,
+    ShakespeareLSTM,
+)
 from utils.loss_function import cross_entropy_loss
 
 
@@ -24,6 +29,8 @@ def create_model(config):
     if dataset in ('femnist', 'emnist') or model_name in ('femnist_cnn', 'emnist_cnn'):
         num_classes = config.get('num_classes', 62)
         return FEMNISTCNN(num_classes=num_classes)
+    if dataset == 'mnist' or model_name == 'mnist_cnn':
+        return MNISTCNN()
     if dataset == 'shakespeare' or model_name in ('shakespeare', 'shakespeare_lstm'):
         vocab_size = config.get('vocab_size', 80)
         return ShakespeareLSTM(vocab_size=vocab_size)

--- a/utils/data_loader.py
+++ b/utils/data_loader.py
@@ -17,7 +17,7 @@ def _get_transform(dataset_name: str):
             transforms.ToTensor(),
             transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
         ])
-    if name in ('emnist', 'femnist'):
+    if name in ('mnist', 'emnist', 'femnist'):
         return transforms.Compose([
             transforms.ToTensor(),
             transforms.Normalize((0.5,), (0.5,)),
@@ -80,6 +80,9 @@ def load_data(
     if name == 'CIFAR-10':
         train_dataset = datasets.CIFAR10(root='./data', train=True, download=True, transform=transform)
         test_dataset = datasets.CIFAR10(root='./data', train=False, download=True, transform=transform)
+    elif name == 'MNIST':
+        train_dataset = datasets.MNIST(root='./data', train=True, download=True, transform=transform)
+        test_dataset = datasets.MNIST(root='./data', train=False, download=True, transform=transform)
     elif name in ('EMNIST', 'FEMNIST'):
         train_dataset = datasets.EMNIST(root='./data', split='byclass', train=True, download=True, transform=transform)
         test_dataset = datasets.EMNIST(root='./data', split='byclass', train=False, download=True, transform=transform)


### PR DESCRIPTION
## Summary
- add compact `MNISTCNN` using two conv-ReLU-pool blocks and a linear classifier
- expose architecture via `__all__` and integrate with experiment runner
- extend data loader and transforms to handle the MNIST dataset

## Testing
- `pytest -q` *(fails: URLError Tunnel connection failed: 403 Forbidden while downloading CIFAR-10 dataset)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ba033bc4832f9277f6ebff9a8114