### PR TITLE
Add run directory metadata handling

### DIFF
--- a/analysis/metadata.py
+++ b/analysis/metadata.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+from datetime import datetime
+import platform
+import subprocess
+import sys
+from typing import Dict
+
+import yaml
+
+
+def create_run_dir(base_path: Path, config: Dict) -> Path:
+    """Create a directory for a single experiment run and store metadata.
+
+    Parameters
+    ----------
+    base_path: Path
+        Root directory where the ``results`` folder will be created.
+    config: dict
+        Experiment configuration to be saved alongside metadata.
+
+    Returns
+    -------
+    Path
+        Path to the newly created run directory ``results/<tag>``.
+    """
+    tag = config.get("tag")
+    if not tag:
+        tag = datetime.now().strftime("%Y%m%d_%H%M%S")
+    run_dir = base_path / "results" / tag
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        git_commit = (
+            subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=base_path)
+            .decode()
+            .strip()
+        )
+    except Exception:
+        git_commit = "unknown"
+
+    metadata = {
+        "config": config,
+        "environment": {
+            "python": sys.version,
+            "platform": platform.platform(),
+        },
+        "git_commit": git_commit,
+    }
+    with (run_dir / "metadata.yaml").open("w") as f:
+        yaml.safe_dump(metadata, f)
+
+    return run_dir
+
+
+__all__ = ["create_run_dir"]

--- a/analysis/reporting.py
+++ b/analysis/reporting.py
@@ -5,6 +5,7 @@ from typing import Any, Dict
 
 import matplotlib.pyplot as plt
 import pandas as pd
+import torch
 
 
 def save_results(results: Dict[str, Any], output_dir: Path) -> None:
@@ -78,6 +79,12 @@ def save_results(results: Dict[str, Any], output_dir: Path) -> None:
         f"FedAvg+KD average loss: {avg_loss_kd:.4f}\n"
     )
     (output_dir / "summary.txt").write_text(summary)
+
+    # Persist final model weights for each algorithm
+    for alg in ["fedavg", "fedavg_kd"]:
+        state = results.get(alg, {}).get("model_state")
+        if state:
+            torch.save(state, output_dir / f"{alg}_model.pt")
 
 
 __all__ = ["save_results"]


### PR DESCRIPTION
## Summary
- add `analysis/metadata.create_run_dir` to manage per-run directories and metadata logging
- persist results and model weights using the run directory
- integrate comparison runner with metadata generation

## Testing
- `pytest -q` *(fails: URLError: <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_68b2da952e24832fa14d17bcd7fdc7b9